### PR TITLE
Trim spaces from ordered product name

### DIFF
--- a/TwilioBarista.Web/Controllers/OrdersController.cs
+++ b/TwilioBarista.Web/Controllers/OrdersController.cs
@@ -113,7 +113,7 @@ namespace TwilioBarista.Web.Controllers
                     DrinkTypeRepository.SelectAll()
                         .AsQueryable()
                         .Include(m => m.Drink)
-                        .Where(m => m.Name == message.Body);
+                        .Where(m => m.Name.Trim() == message.Body.Trim());
                 var drinkMatch = drink.Select(p => p.Drink.Name).FirstOrDefault();
                 string response;
                 if (drink.Any())


### PR DESCRIPTION
Tried ordering coffee before having any coffee, and got confused when " Latte" wasn't recognized.
Edited on a phone, hopefully won't break anything important.